### PR TITLE
Support pip '-pre' option for wheel_builder

### DIFF
--- a/yaprt/__init__.py
+++ b/yaprt/__init__.py
@@ -195,6 +195,7 @@ ARGUMENTS_DICT = {
                             'pip_extra_index',
                             'pip_no_deps',
                             'pip_no_index',
+                            'pip_pre',
                             'pip_extra_link_dirs'
                         ]
                     }
@@ -271,6 +272,14 @@ ARGUMENTS_DICT = {
                     ],
                     'help': 'Ignore package index (only looking at'
                             ' --link-dir URLs instead).',
+                    'action': 'store_true',
+                    'default': False
+                },
+                'pip_pre': {
+                    'commands': [
+                        '--pip-pre'
+                    ],
+                    'help': 'Include pre-release and development versions.',
                     'action': 'store_true',
                     'default': False
                 },

--- a/yaprt/wheel_builder.py
+++ b/yaprt/wheel_builder.py
@@ -118,6 +118,7 @@ class WheelBuilder(utils.RepoBaseClass):
         ...     'build_dir': '/tmp/build_place',
         ...     'pip_no_deps': True,
         ...     'pip_no_index': True,
+        ...     'pip_pre': False,
         ...     'link_dir': '/var/www/repo',
         ...     'debug': True,
         ...     'duplicate_handling': 'max',
@@ -231,6 +232,9 @@ class WheelBuilder(utils.RepoBaseClass):
             self.args['build_output'],
             '--allow-all-external'
         ]
+
+        if self.args['pip_pre']:
+            command.append('--pre')
 
         if not no_links:
             if self.args['pip_extra_link_dirs']:


### PR DESCRIPTION
'-pre' option allows pip to include pre-release and development versions.
