### PR TITLE
UTF-8 encode contents of requirements file

### DIFF
--- a/yaprt/wheel_builder.py
+++ b/yaprt/wheel_builder.py
@@ -862,7 +862,9 @@ class WheelBuilder(utils.RepoBaseClass):
                 LOG.info('Requirement file being written: "%s"', req_file)
                 self.shell_cmds.mkdir_p(path=os.path.dirname(req_file))
                 with open(req_file, 'wb') as f:
-                    f.writelines(['%s\n' % i for i in packages])
+                    f.writelines(
+                        ['%s\n' % i.encode('UTF-8') for i in packages]
+                    )
 
                 self._pip_build_wheels(packages_file=req_file)
             else:


### PR DESCRIPTION
This ensures we don't get encoding erros when passing our requirements file to
pip during the wheel building process.

Closes #7
